### PR TITLE
Update TableMapper.cs

### DIFF
--- a/src/Dapper.Bulk.Shared/TableMapper.cs
+++ b/src/Dapper.Bulk.Shared/TableMapper.cs
@@ -32,6 +32,8 @@ namespace Dapper.Bulk
 
             _prefix = tablePrefix;
             _suffix = tableSuffix;
+            
+            TableNames.Clear();
         }
         
         internal static string GetTableName(Type type)


### PR DESCRIPTION
Hi,

There's really no way to switch between naming conventions as the TableMapper is a static class with a static dictionary.
This cache persists through the lifetime of the application which is not ideal.

The proposed change is to clear TableNames on SetupConvention call.