### PR TITLE
Fix temporary table naming by removing '.' from name

### DIFF
--- a/src/Dapper.Bulk/DapperBulk.cs
+++ b/src/Dapper.Bulk/DapperBulk.cs
@@ -31,7 +31,7 @@ namespace Dapper.Bulk
 
             var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
             var allPropertiesExceptKeyAndComputedString = GetColumnsStringSqlServer(allPropertiesExceptKeyAndComputed);
-            var tempToBeInserted = $"#{tableName}_TempInsert";
+            var tempToBeInserted = $"#{tableName}_TempInsert".Replace(".", string.Empty);
 
             connection.Execute($@"SELECT TOP 0 {allPropertiesExceptKeyAndComputedString} INTO {tempToBeInserted} FROM {tableName} target WITH(NOLOCK);", null, transaction);
 
@@ -82,8 +82,8 @@ namespace Dapper.Bulk
             var allPropertiesExceptKeyAndComputedString = GetColumnsStringSqlServer(allPropertiesExceptKeyAndComputed);
             var allPropertiesString = GetColumnsStringSqlServer(allProperties, "target.");
 
-            var tempToBeInserted = $"#{tableName}_TempInsert";
-            var tempInsertedWithIdentity = $"@{tableName}_TempInserted";
+            var tempToBeInserted = $"#{tableName}_TempInsert".Replace(".", string.Empty);
+            var tempInsertedWithIdentity = $"@{tableName}_TempInserted".Replace(".", string.Empty);
 
             connection.Execute($"SELECT TOP 0 {allPropertiesExceptKeyAndComputedString} INTO {tempToBeInserted} FROM {tableName} target WITH(NOLOCK);", null, transaction);
 
@@ -127,7 +127,7 @@ namespace Dapper.Bulk
             var computedProperties = PropertiesCache.ComputedPropertiesCache(type);
             var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
             var allPropertiesExceptKeyAndComputedString = GetColumnsStringSqlServer(allPropertiesExceptKeyAndComputed);
-            var tempToBeInserted = $"#{tableName}_TempInsert";
+            var tempToBeInserted = $"#{tableName}_TempInsert".Replace(".", string.Empty);
 
             await connection.ExecuteAsync($@"SELECT TOP 0 {allPropertiesExceptKeyAndComputedString} INTO {tempToBeInserted} FROM {tableName} target WITH(NOLOCK);", null, transaction);
 
@@ -177,8 +177,8 @@ namespace Dapper.Bulk
             var allPropertiesExceptKeyAndComputedString = GetColumnsStringSqlServer(allPropertiesExceptKeyAndComputed);
             var allPropertiesString = GetColumnsStringSqlServer(allProperties, "target.");
 
-            var tempToBeInserted = $"#{tableName}_TempInsert";
-            var tempInsertedWithIdentity = $"@{tableName}_TempInserted";
+            var tempToBeInserted = $"#{tableName}_TempInsert".Replace(".", string.Empty);
+            var tempInsertedWithIdentity = $"@{tableName}_TempInserted".Replace(".", string.Empty);
 
             await connection.ExecuteAsync($@"SELECT TOP 0 {allPropertiesExceptKeyAndComputedString} INTO {tempToBeInserted} FROM {tableName} target WITH(NOLOCK);", null, transaction);
 


### PR DESCRIPTION
Closes #2 