### PR TITLE
Added non-generic overload for calling BulkInsert, and fixed bug for …

### DIFF
--- a/src/Dapper.Bulk.Shared/PropertiesCache.cs
+++ b/src/Dapper.Bulk.Shared/PropertiesCache.cs
@@ -102,7 +102,8 @@ namespace Dapper.Bulk
             foreach (var prop in props)
             {
                 var columnAttr = prop.GetCustomAttributes(false).SingleOrDefault(attr => attr.GetType().Name == "ColumnAttribute") as dynamic;
-                ret.Add(prop.Name, columnAttr != null ? (string)columnAttr.Name : prop.Name);
+                // if the column attribute exists, and specifies a column name, use that, otherwise fall back to the property name as the column name
+                ret.Add(prop.Name, columnAttr != null ? (string)columnAttr.Name??prop.Name : prop.Name);
             }
 
             return ret;

--- a/src/Dapper.Bulk/DapperBulk.cs
+++ b/src/Dapper.Bulk/DapperBulk.cs
@@ -28,6 +28,21 @@ namespace Dapper.Bulk
         public static void BulkInsert<T>(this SqlConnection connection, IEnumerable<T> data, SqlTransaction transaction = null, int batchSize = 0, int bulkCopyTimeout = 30)
         {
             var type = typeof(T);
+            BulkInsert(connection,type,data.Cast<object>(),transaction,batchSize,bulkCopyTimeout);
+        }
+
+        /// <summary>
+        /// Inserts entities into table.
+        /// by default, the table is named after the data type specified.
+        /// </summary>
+        /// <param name="connection">Open SqlConnection</param>
+        /// <param name="type">The type being inserted.</param>
+        /// <param name="data">Entities to insert</param>
+        /// <param name="transaction">The transaction to run under, null (the default) if none</param>
+        /// <param name="batchSize">Number of bulk items inserted together, 0 (the default) if all</param>
+        /// <param name="bulkCopyTimeout">Number of seconds before bulk command execution timeout, 30 (the default)</param>
+        public static void BulkInsert(this SqlConnection connection, Type type, IEnumerable<object> data, SqlTransaction transaction = null, int batchSize = 0, int bulkCopyTimeout = 30)
+        { 
             var tableName = TableMapper.GetTableName(type);
             var allProperties = PropertiesCache.TypePropertiesCache(type);
             var keyProperties = PropertiesCache.KeyPropertiesCache(type);


### PR DESCRIPTION
1) Added non-generic overload for calling BulkInsert, allows callers to take entities from an EF data context and pass them to BulkInsert without declaring the entity type.  

2) Fixed a bug that required the column name property to be set when using the column attribute on a property.  Often, we only declare the column type, leaving the column name as the property name.  This fix supports this use case.
this:

  [Column(TypeName = "decimal(9, 2)")]
  public decimal? DebitAmount { get; set; }

Rather than:

  [Column("DebitAmount",TypeName = "decimal(9, 2)")]
  public decimal? DebitAmount { get; set; }




