### PR TITLE
allows explicitkey id property to bulk insert

### DIFF
--- a/src/Dapper.Bulk.Shared/PropertiesCache.cs
+++ b/src/Dapper.Bulk.Shared/PropertiesCache.cs
@@ -84,6 +84,17 @@ namespace Dapper.Bulk
             return keyProperties;
         }
 
+        public static List<PropertyInfo> ExplicitKeyPropertiesCache(Type type)
+        {
+            var keyProperties = KeyPropertiesCache(type);
+            var explicitKeys = keyProperties
+               .Where<PropertyInfo>(p => ((IEnumerable<object>)p.GetCustomAttributes(true))
+               .Any<object>((Func<object, bool>)(a => a.GetType().Name == "ExplicitKeyAttribute")))
+               .ToList<PropertyInfo>();
+
+            return explicitKeys;
+        }
+
         public static List<PropertyInfo> ComputedPropertiesCache(Type type)
         {
             if (ComputedProperties.TryGetValue(type.TypeHandle, out var cachedProps))

--- a/src/Dapper.Bulk/DapperBulk.cs
+++ b/src/Dapper.Bulk/DapperBulk.cs
@@ -46,10 +46,11 @@ namespace Dapper.Bulk
             var tableName = TableMapper.GetTableName(type);
             var allProperties = PropertiesCache.TypePropertiesCache(type);
             var keyProperties = PropertiesCache.KeyPropertiesCache(type);
+            var explicitKeyProperties = PropertiesCache.ExplicitKeyPropertiesCache(type);
             var computedProperties = PropertiesCache.ComputedPropertiesCache(type);
             var columns = PropertiesCache.GetColumnNamesCache(type);
 
-            var allPropertiesExceptKeyAndComputed = allProperties.Except(keyProperties.Union(computedProperties)).ToList();
+            var allPropertiesExceptKeyAndComputed = explicitKeyProperties.Count > 0 ? allProperties :allProperties.Except(keyProperties.Union(computedProperties)).ToList();
             var allPropertiesExceptKeyAndComputedString = GetColumnsStringSqlServer(allPropertiesExceptKeyAndComputed, columns);
             var tempToBeInserted = $"#TempInsert_{tableName}".Replace(".", string.Empty);
 


### PR DESCRIPTION
We got error while try to bulk insert.
Cannot insert the value NULL into column 'Id' without autoincrement id

when trying to give a value to id(explicitkey) it gives a "cannot insert null value to id" error,
although I should be able to give a value on non auto increment id column

This commit ignores explicit keys from allProperties.Except operation.