### PR TITLE
Added byte[] type support

### DIFF
--- a/src/Dapper.Bulk.Shared/PropertiesCache.cs
+++ b/src/Dapper.Bulk.Shared/PropertiesCache.cs
@@ -45,7 +45,7 @@ namespace Dapper.Bulk
         {
             var result = prop.CanWrite; 
             result = result && (prop.GetSetMethod(true)?.IsPublic ?? false);
-            result = result && (!prop.PropertyType.IsClass || prop.PropertyType == typeof(string));
+            result = result && (!prop.PropertyType.IsClass || prop.PropertyType == typeof(string) || prop.PropertyType == typeof(byte[]));
             result = result && prop.GetCustomAttributes(true).All(a => a.GetType().Name != "NotMappedAttribute");
 
             var writeAttribute = prop.GetCustomAttributes(true).FirstOrDefault(x => x.GetType().Name == "WriteAttribute");

--- a/src/Dapper.Bulk/Dapper.Bulk.csproj
+++ b/src/Dapper.Bulk/Dapper.Bulk.csproj
@@ -15,8 +15,8 @@
     <Description>Fast bulk insert extensions for Dapper.</Description>
     <PackageReleaseNotes>-Fixed issues #8 and #10</PackageReleaseNotes>
     <Company>Mk</Company>
-    <AssemblyVersion>1.4.2.0</AssemblyVersion>
-    <FileVersion>1.4.2.0</FileVersion>
+    <AssemblyVersion>1.4.3.0</AssemblyVersion>
+    <FileVersion>1.4.3.0</FileVersion>
     <Version>1.4.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>

--- a/src/Dapper.Bulk/Dapper.Bulk.csproj
+++ b/src/Dapper.Bulk/Dapper.Bulk.csproj
@@ -6,7 +6,7 @@
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
-    <PackageLicenseUrl>https://github.com/KostovMartin/Dapper.Bulk/blob/master/LICENSE</PackageLicenseUrl>
+    <PackageLicenseUrl></PackageLicenseUrl>
     <PackageProjectUrl>https://github.com/KostovMartin/Dapper.Bulk</PackageProjectUrl>
     <RepositoryUrl>https://github.com/KostovMartin/Dapper.Bulk</RepositoryUrl>
     <Authors>Martin Kostov</Authors>
@@ -17,8 +17,9 @@
     <Company>Mk</Company>
     <AssemblyVersion>1.4.2.0</AssemblyVersion>
     <FileVersion>1.4.2.0</FileVersion>
-    <Version>1.4.2</Version>
+    <Version>1.4.3</Version>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <PackageLicenseFile>LICENSE</PackageLicenseFile>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -58,6 +59,13 @@
   <ItemGroup>
     <Compile Include="..\Dapper.Bulk.Shared\PropertiesCache.cs" />
     <Compile Include="..\Dapper.Bulk.Shared\TableMapper.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <None Include="..\..\LICENSE">
+      <Pack>True</Pack>
+      <PackagePath></PackagePath>
+    </None>
   </ItemGroup>
   
 </Project>

--- a/tests/Dapper.Bulk.Tests/ByteArrayTests.cs
+++ b/tests/Dapper.Bulk.Tests/ByteArrayTests.cs
@@ -1,0 +1,50 @@
+﻿using FluentAssertions;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using Xunit;
+
+namespace Dapper.Bulk.Tests
+{
+    public class ByteArrayTests : SqlServerTestSuite
+    {
+        private class ByteArray
+        {
+            public int Id { get; set; }
+
+            public byte[] TestArray { get; set; }
+        }
+
+        [Fact]
+        public void InsertBulk()
+        {
+            var data = new List<ByteArray>();
+            for (var i = 0; i < 10; i++)
+            {
+                data.Add(new ByteArray
+                {
+                    Id = i,
+                    TestArray = Encoding.ASCII.GetBytes(Path.GetRandomFileName()),
+                });
+            }
+
+            using (var connection = this.GetConnection())
+            {
+                connection.Open();
+                var inserted = connection.BulkInsertAndSelect(data).ToList();
+                for (var i = 0; i < data.Count; i++)
+                {
+                    IsValidInsert(inserted[i], data[i]);
+                }
+            }
+        }
+
+        private static void IsValidInsert(ByteArray inserted, ByteArray toBeInserted)
+        {
+            inserted.Id.Should().BePositive();
+            inserted.TestArray.Should().Match(x => x.Select(y => toBeInserted.TestArray.Contains(y)).Any());            
+        }
+    }
+}

--- a/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
+++ b/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
@@ -40,6 +40,13 @@ namespace Dapper.Bulk.Tests
                     );");
 
                 connection.Execute(
+                    $@"{DropTable("ByteArrays")}
+                    CREATE TABLE ByteArrays(
+	                    [Id] BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+	                    [TestArray] varbinary(100) NOT NULL
+                    );");
+
+                connection.Execute(
                   $@"{DropTable("IdentityAndNotMappedTests")}
                     CREATE TABLE IdentityAndNotMappedTests
                     (


### PR DESCRIPTION
The PropertiesCache.cs and test file are all that strictly need to change. The changes to the project file are mostly due to not being able to compile properly without changing the handling of the license file, though I did increment the version number as well.