### PR TITLE
Allow ColumnName and Key on the same field

### DIFF
--- a/src/Dapper.Bulk/DapperBulk.cs
+++ b/src/Dapper.Bulk/DapperBulk.cs
@@ -131,8 +131,8 @@ namespace Dapper.Bulk
                 bulkCopy.WriteToServer(ToDataTable(data, insertProperties).CreateDataReader());
             }
 
-            var table = string.Join(", ", keyProperties.Select(k => $"[{k.Name }] bigint"));
-            var joinOn = string.Join(" AND ", keyProperties.Select(k => $"target.[{k.Name }] = ins.[{k.Name }]"));
+            var table = string.Join(", ", keyProperties.Select(k => $"[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}] bigint"));
+            var joinOn = string.Join(" AND ", keyProperties.Select(k => $"target.[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}] = ins.[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}]"));
             
             return connection.Query<T>($@"
                 {identityInsertOn}
@@ -248,8 +248,8 @@ namespace Dapper.Bulk
                 await bulkCopy.WriteToServerAsync(ToDataTable(data, insertProperties).CreateDataReader());
             }
 
-            var table = string.Join(", ", keyProperties.Select(k => $"[{k.Name }] bigint"));
-            var joinOn = string.Join(" AND ", keyProperties.Select(k => $"target.[{k.Name }] = ins.[{k.Name }]"));
+            var table = string.Join(", ", keyProperties.Select(k => $"[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}] bigint"));
+            var joinOn = string.Join(" AND ", keyProperties.Select(k => $"target.[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}] = ins.[{(columns.ContainsKey(k.Name) ? columns[k.Name] : k.Name)}]"));
             return await connection.QueryAsync<T>($@"
                 {identityInsertOn}
                 DECLARE {tempInsertedWithIdentity} TABLE ({table})

--- a/tests/Dapper.Bulk.Tests/CustomColumnNameTests.cs
+++ b/tests/Dapper.Bulk.Tests/CustomColumnNameTests.cs
@@ -13,7 +13,7 @@ namespace Dapper.Bulk.Tests
     {
         private class CustomColumnName
         {
-            [Key]
+            [Key, Column("Id_Key")]
             public int IdKey { get; set; }
 
             [Column("Name_1")]

--- a/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
+++ b/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.SqlClient;
+using System.Data.SqlClient;
 
 namespace Dapper.Bulk.Tests
 {
@@ -66,7 +66,7 @@ namespace Dapper.Bulk.Tests
                   $@"{DropTable("CustomColumnNames")}
                     CREATE TABLE CustomColumnNames
                     (
-	                    [IdKey] BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
+	                    [Id_Key] BIGINT IDENTITY(1,1) NOT NULL PRIMARY KEY,
 	                    [Name_1] NVARCHAR(100) NULL,
                         [Int_Col] INT NOT NULL,
 	                    [Long_Col] BIGINT NOT NULL


### PR DESCRIPTION
Fix bug where using a custom column name on the key column uses the wrong column name, update column name unit test to check.