### PR TITLE
Reference package   Microsoft.Data.SqlClient  instead of  System.Data.SqlClient

### DIFF
--- a/src/Dapper.Bulk.Shared/Dapper.Bulk.Shared.csproj
+++ b/src/Dapper.Bulk.Shared/Dapper.Bulk.Shared.csproj
@@ -1,8 +1,12 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
     <RootNamespace>Dapper.Bulk</RootNamespace>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
+  </ItemGroup>
 
 </Project>

--- a/src/Dapper.Bulk/Dapper.Bulk.csproj
+++ b/src/Dapper.Bulk/Dapper.Bulk.csproj
@@ -36,6 +36,7 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.CSharp" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="5.1.0" />
     <PackageReference Include="System.Dynamic.Runtime" Version="4.3.0" />
     <PackageReference Include="Dapper" Version="1.60.6" />
   </ItemGroup>

--- a/src/Dapper.Bulk/DapperBulk.cs
+++ b/src/Dapper.Bulk/DapperBulk.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using System.Linq;
 using System.Reflection;
 using System.Runtime.CompilerServices;

--- a/tests/Dapper.Bulk.Tests/Dapper.Bulk.Tests.csproj
+++ b/tests/Dapper.Bulk.Tests/Dapper.Bulk.Tests.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net5.0</TargetFramework>
+    <TargetFramework>net6.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>

--- a/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
+++ b/tests/Dapper.Bulk.Tests/SqlServerTestSuite.cs
@@ -1,4 +1,4 @@
-﻿using System.Data.SqlClient;
+﻿using Microsoft.Data.SqlClient;
 
 namespace Dapper.Bulk.Tests
 {


### PR DESCRIPTION
Reference package   Microsoft.Data.SqlClient  instead of  System.Data.SqlClient
[https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/](url)