### PR TITLE
Net Standard 2.0 support dropped?

### DIFF
--- a/src/Dapper.Bulk.Shared/Dapper.Bulk.Shared.csproj
+++ b/src/Dapper.Bulk.Shared/Dapper.Bulk.Shared.csproj
@@ -1,8 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net6.0</TargetFramework>
+	<TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;</TargetFrameworks>
     <RootNamespace>Dapper.Bulk</RootNamespace>
+    <LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <ItemGroup>

--- a/src/Dapper.Bulk.Shared/TableMapper.cs
+++ b/src/Dapper.Bulk.Shared/TableMapper.cs
@@ -57,7 +57,7 @@ public static class TableMapper
         }
         else
         {
-            name = type.IsInterface && type.Name.StartsWith("I") ? type.Name[1..] : type.Name;
+            name = type.IsInterface && type.Name.StartsWith("I") ? type.Name.Substring(1) : type.Name;
             name = $"{_prefix}{name}{_suffix}";
         }
 

--- a/src/Dapper.Bulk/Dapper.Bulk.csproj
+++ b/src/Dapper.Bulk/Dapper.Bulk.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>Dapper.Bulk</AssemblyName>
-    <TargetFramework>net6.0</TargetFramework>
+    <TargetFrameworks>netstandard2.0;netstandard2.1;net6.0;</TargetFrameworks>
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
     <NeutralLanguage>en</NeutralLanguage>
     <PackageRequireLicenseAcceptance>false</PackageRequireLicenseAcceptance>
@@ -25,6 +25,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
     <PackageLicenseFile>LICENSE</PackageLicenseFile>
 	<PackageReadmeFile>README.md</PackageReadmeFile>
+	<LangVersion>10</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
@@ -52,7 +53,7 @@
       <Pack>True</Pack>
       <PackagePath></PackagePath>
     </None>
-	<None Include="..\..\README.md" Pack="true" PackagePath="\"/>
+	  <None Include="..\..\README.md" Pack="true" PackagePath="\"/>
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
Net Standard 2.0 support dropped?  Just went to update nugets on a net standard library I have and noticed that it couldn't update.

Its looks like the only a couple things need to be done to maintain netstandard2.0 compatibility. 

-set the language version to 10 in the csproj's
-replace a range operator with a Substring in TableMapper.cs